### PR TITLE
local-mysql-server-구축을-위한-docker-compose-file-추가

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+TZ=Asia/Seoul
+MYSQL_HOST=localhost
+MYSQL_PORT=3306
+MYSQL_ROOT_PASSWORD=compact!
+MYSQL_DATABASE=jmc
+MYSQL_USER=compact
+MYSQL_PASSWORD=compact!

--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,8 @@ out/
 /nbdist/
 /.nb-gradle/
 
+### DataBase ###
+/db/
+
 ### VS Code ###
 .vscode/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3"
+services:
+  db:
+    image: mariadb:10
+    ports:
+      - 3306:3306
+    volumes:
+      - ./db/conf.d:/etc/mysql/conf.d
+      - ./db/data:/var/lib/mysql
+      - ./db/initdb.d:/docker-entrypoint-initdb.d
+    env_file: .env
+    environment:
+      TZ: Asia/Seoul
+    networks:
+      - backend
+    restart: always
+
+networks:
+  backend:


### PR DESCRIPTION
## 📚 개요

> 로컬 디비 구축을 편하게 하기위한 docker-compose.yml 파일입니다.
> 1. docker desktop 을 설치합니다.
> 2. 프로젝트 터미널에서 docker-compose up 을 입력합니다.
> 3. localhost에 3306포트로 연결하면 됩니다.
> 자세한건 구글링해보세용

## 🕐 리뷰 예상 시간

> 2m

## ❗❗ 중요한 변경점(Option)

> 현재는 ddl 형상관리가 되어있지 않아서 추후 ddl 형상관리 툴도 붙일 예정입니다. (아마도 liquibase나 flyway 사용할거 같습니다.)